### PR TITLE
Solución recargar imágenes de perfil

### DIFF
--- a/resources/js/Pages/Profile/Partials/UpdateProfileImagesForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileImagesForm.jsx
@@ -50,7 +50,7 @@ const ImageUploadForm = () => {
                 name="profile_image"
                 label="Profile Image"
                 onChange={(file) => setData('profile_image', file)}
-                initialImage={user.profile_image ? `/storage/${user.profile_image}` : null}
+                initialImage={user.profile_image ? `/storage/${user.profile_image}?t=${new Date().getTime()})` : null}
             />
             {errors.profile_image && <div className="text-red-500">{errors.profile_image}</div>}
 
@@ -58,7 +58,7 @@ const ImageUploadForm = () => {
                 name="background_image"
                 label="Background Image"
                 onChange={(file) => setData('background_image', file)}
-                initialImage={user.background_image ? `/storage/${user.background_image}` : null}
+                initialImage={user.background_image ? `/storage/${user.background_image}?t=${new Date().getTime()})` : null}
             />
             {errors.background_image && <div className="text-red-500">{errors.background_image}</div>}
 


### PR DESCRIPTION
Este PR soluciona el problema donde las imágenes no se actualizaban correctamente al navegar entre diferentes URLs. Ahora, las imágenes se recargan automáticamente después de una actualización, evitando la necesidad de refrescar manualmente la página.