### PR TITLE
[RF] Gestión usuario - Problema biografia null arreglado

### DIFF
--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -82,7 +82,7 @@ export default function UpdateProfileInformation({
                     <TextAreaInput
                         id="biografia"
                         className="mt-1 block w-full"
-                        value={data.biografia}
+                        value={data.biografia || ''}
                         onChange={(e) => setData('biografia', e.target.value)}
                         placeholder="Tell us about yourself"
                         rows={4}


### PR DESCRIPTION
Este PR soluciona un problema donde, si el usuario no tenía biografía, se mostraba null en su perfil. Ahora, si no hay biografía, se muestra un valor vacío o un espacio adecuado en lugar de null.