### PR TITLE
[RF] Visualizar álbum mediante Flipbook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "react-pageflip": "^2.0.3"
+            },
             "devDependencies": {
                 "@headlessui/react": "^2.0.0",
                 "@inertiajs/react": "^2.0.0",
@@ -3576,6 +3579,12 @@
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
+        "node_modules/page-flip": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/page-flip/-/page-flip-2.0.7.tgz",
+            "integrity": "sha512-96lQFUUz7r/LZzEUZJ3yBIMEKU9+m8HMFDzTvTdD6P7Ag/wXINjp9n0W7b4wanwnDbQETo4uNUoL3zMqpFxwGA==",
+            "license": "MIT"
+        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3876,6 +3885,15 @@
             },
             "peerDependencies": {
                 "react": "^18.3.1"
+            }
+        },
+        "node_modules/react-pageflip": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/react-pageflip/-/react-pageflip-2.0.3.tgz",
+            "integrity": "sha512-k81mHhRvUM52y8jyzTCh5t4O0lepkLhp+XGSUzq2C3uD+iW99Cv0jfRlqFCjZbD5N3jKkIFr7/3giucoXKDP3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "page-flip": "latest"
             }
         },
         "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
         "react-dom": "^18.2.0",
         "tailwindcss": "^3.4.17",
         "vite": "^6.0.11"
+    },
+    "dependencies": {
+        "react-pageflip": "^2.0.3"
     }
 }

--- a/resources/js/Components/Albums/Album.jsx
+++ b/resources/js/Components/Albums/Album.jsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import { Link, usePage } from '@inertiajs/react';
 import Edit from '@/Components/Albums/Edit'; // Importamos el modal de edición
+import FlipBook from '@/Components/Albums/FlipBook'; // Importamos el modal FlipBook
 
 const Album = ({ album }) => {
   const { auth } = usePage().props; // Obtener el usuario autenticado desde Inertia
 
   // Estado para controlar la apertura del modal de edición
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isFlipBookOpen, setIsFlipBookOpen] = useState(false); // Estado para FlipBook
 
   // Verificar si el usuario puede editar o eliminar el álbum
   const canEditOrDelete = auth.user.id === album.user.id || auth.user.is_admin;
@@ -46,6 +48,11 @@ const Album = ({ album }) => {
         Ver álbum completo
       </Link>
 
+      {/* Enlace para ver el FlipBook */}
+      <button onClick={() => setIsFlipBookOpen(true)} className="text-blue-500 mt-2 block">
+        Ver Flipbook
+      </button>
+
       {/* Botones solo visibles si el usuario tiene permiso */}
       {canEditOrDelete && (
         <div className="mt-4 flex space-x-4">
@@ -61,6 +68,9 @@ const Album = ({ album }) => {
 
       {/* Mostrar el modal de edición si isEditModalOpen es verdadero */}
       {isEditModalOpen && <Edit album={album} onClose={() => setIsEditModalOpen(false)} />}
+
+      {/* Mostrar el modal FlipBook si isFlipBookOpen es verdadero */}
+      {isFlipBookOpen && <FlipBook isOpen={isFlipBookOpen} onClose={() => setIsFlipBookOpen(false)} album={album} />}
     </div>
   );
 };

--- a/resources/js/Components/Albums/FlipBook.jsx
+++ b/resources/js/Components/Albums/FlipBook.jsx
@@ -1,0 +1,151 @@
+import { useState, useRef } from "react";
+import React from 'react';
+import HTMLFlipBook from "react-pageflip";
+
+export default function FlipBook({ isOpen, onClose, album }) {
+
+  if (!isOpen) return null;
+
+  // Referencia para el flipbook
+  const flipBookRef = useRef(null);
+
+  // Estado para la página actual
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+
+  const postsImpares = album.posts.length % 2 !== 0;
+
+  // Funciones para manejar los eventos
+  const onPage = (e) => {
+    setPage(flipBookRef.current.pageFlip().getCurrentPageIndex() + 1);
+    setTotalPages(flipBookRef.current.pageFlip().getPageCount());
+    console.log('Página volteada:', e);
+  };
+
+  const onChangeOrientation = (e) => {
+    console.log('Orientación cambiada:', e);
+  };
+
+  const onChangeState = (e) => {
+    console.log('Estado cambiado:', e);
+  };
+
+  // Funciones para el control de las páginas
+  const nextButtonClick = () => {
+    if (flipBookRef.current) {
+      flipBookRef.current.pageFlip().flipNext();
+    }
+  };
+
+  const prevButtonClick = () => {
+    if (flipBookRef.current) {
+      flipBookRef.current.pageFlip().flipPrev();
+    }
+  };
+
+  const width = window.innerWidth;
+  const height = width * (2 / 3);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 overflow-hidden">
+      {/* Modal ocupa todo el viewport */}
+      <div className="bg-white p-0 rounded-lg shadow-xl w-full h-full flex flex-col items-center overflow-hidden">
+        {/* Título del álbum */}
+        <h2 className="text-2xl font-semibold mb-4 absolute top-4 left-1/2 transform -translate-x-1/2 z-10">{album.nombre}</h2>
+
+        <div className="flex items-center justify-center w-full h-full flex-grow overflow-hidden pl-10 pr-10">
+          <HTMLFlipBook
+            width={width} // Se ajusta al tamaño del modal
+            height={height} // Se ajusta al tamaño del modal
+            size="stretch"
+            minWidth={315}
+            maxWidth={1000}
+            minHeight={400}
+            maxHeight={1533}
+            maxShadowOpacity={0.5}
+            drawShadow={true}
+            showCover={true}
+            mobileScrollSupport={true}
+            onFlip={onPage}
+            onChangeOrientation={onChangeOrientation}
+            onChangeState={onChangeState}
+            ref={flipBookRef}
+          >
+            {/* Portada como una página dura */}
+            <div className="w-full h-full flex items-center justify-center">
+              <div className="page-content w-full h-full">
+                <img
+                  src={`/storage/${album.portada}?t=${new Date().getTime()}`}
+                  alt={album.nombre}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            </div>
+
+            {/* Páginas del álbum */}
+            {album.posts.map((post, index) => (
+              <div key={index} className="w-full h-full flex items-center justify-center">
+                <div className="page-content w-full h-full">
+                  <img
+                    src={`/storage/${post.photo.url}?t=${new Date().getTime()}`}
+                    alt={post.photo.localizacion || `Photo ${index + 1}`}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+              </div>
+            ))}
+
+            {postsImpares ? (
+            <>
+                <div className="w-full h-full flex items-center justify-center bg-gray-200">
+                {/* Página vacía */}
+                </div>
+
+                <div className="w-full h-full flex items-center justify-center">
+                <div className="page-content w-full h-full">
+                    <img
+                    src={`/storage/${album.portada}?t=${new Date().getTime()}`}
+                    alt={album.nombre}
+                    className="w-full h-full object-cover"
+                    />
+                </div>
+                </div>
+            </>
+            ) : (
+            // Si no hay página vacía (postsImpares es false)
+            <div className="w-full h-full flex items-center justify-center">
+                <div className="page-content w-full h-full">
+                <img
+                    src={`/storage/${album.portada}?t=${new Date().getTime()}`}
+                    alt={album.nombre}
+                    className="w-full h-full object-cover"
+                />
+                </div>
+            </div>
+            )}
+
+          </HTMLFlipBook>
+        </div>
+
+        <div className="container">
+          <div>
+            <button type="button" onClick={prevButtonClick}>
+              Página anterior
+            </button>
+             <span> {page}</span> de <span> {totalPages} </span>
+            <button type="button" onClick={nextButtonClick}>
+              Siguiente página
+            </button>
+          </div>
+        </div>
+
+        <button
+          onClick={onClose}
+          className="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-900 absolute top-2 right-2 z-10"
+        >
+          ✖
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,7 +62,7 @@ Route::get('/mis-albums', function () {
     $user = User::findOrFail($userId);
 
     return Inertia::render('Albums/MisAlbums', [
-        'albums' => $user->albums()->with('posts', 'user')->orderBy('created_at', 'desc')->get(),
+        'albums' => $user->albums()->with('posts', 'user', 'posts.photo')->orderBy('created_at', 'desc')->get(),
         'posts' => $user->posts()->with('photo', 'tags', 'user')->get(),
     ]);
 })->middleware('auth')->name('mis-albums');


### PR DESCRIPTION
Este PR implementa la funcionalidad de visualización interactiva de las fotos de los posts de un álbum mediante FlipBook, un visor de imágenes que permite pasar las páginas de forma animada.

Se añadió la librería react-pageflip para manejar el efecto de pase de páginas.

- Closes #64 
- Closes #65 