### PR TITLE
Soluión error modal añadir publicaciones al álbum.

### DIFF
--- a/resources/js/Components/Albums/AddPosts.jsx
+++ b/resources/js/Components/Albums/AddPosts.jsx
@@ -4,16 +4,14 @@ import { router } from '@inertiajs/react';
 const AddPosts = ({ album, userPosts, onClose }) => {
   const [selectedPosts, setSelectedPosts] = useState([]);
 
-  // Maneja la selección de posts
   const togglePostSelection = (postId) => {
     setSelectedPosts((prevSelected) =>
       prevSelected.includes(postId)
-        ? prevSelected.filter((id) => id !== postId) // Quitar si ya está seleccionado
-        : [...prevSelected, postId] // Agregar si no está seleccionado
+        ? prevSelected.filter((id) => id !== postId)
+        : [...prevSelected, postId]
     );
   };
 
-  // Maneja el envío del formulario
   const handleSubmit = (e) => {
     e.preventDefault();
 
@@ -28,23 +26,21 @@ const AddPosts = ({ album, userPosts, onClose }) => {
     });
   };
 
-  // Efecto para prevenir el scroll en el body cuando el modal está abierto
   useEffect(() => {
-    document.body.style.overflow = 'hidden'; // Deshabilitar scroll en el body cuando el modal está abierto
+    document.body.style.overflow = 'hidden';
     return () => {
-      document.body.style.overflow = 'auto'; // Restaurar el scroll al cerrar el modal
+      document.body.style.overflow = 'auto';
     };
   }, []);
 
   return (
     <div className="fixed inset-0 bg-gray-500 bg-opacity-50 flex justify-center items-center z-50">
-      {/* Modal con tamaño similar al paso 2 */}
       <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-4xl h-[90%] overflow-hidden flex flex-col">
         <h3 className="text-xl font-semibold mb-4">Seleccionar Posts</h3>
 
         <form onSubmit={handleSubmit} className="flex flex-col flex-grow">
-          {/* Contenedor de los posts con scroll */}
-          <div className="max-h-[80%] overflow-y-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
+          {/* Contenedor de posts con scroll */}
+          <div className="flex-grow overflow-y-auto p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-h-[70vh]">
             {userPosts.length === 0 ? (
               <p className="text-gray-500">No tienes posts disponibles.</p>
             ) : (
@@ -53,10 +49,10 @@ const AddPosts = ({ album, userPosts, onClose }) => {
                   key={post.id}
                   className={`relative cursor-pointer rounded-md transition-all transform ${
                     selectedPosts.includes(post.id)
-                      ? 'border-4 border-blue-500 shadow-lg bg-blue-100' // Estilo cuando está seleccionado
+                      ? 'border-4 border-blue-500 shadow-lg bg-blue-100'
                       : 'bg-white'
                   }`}
-                  onClick={() => togglePostSelection(post.id)} // Alternar selección de post
+                  onClick={() => togglePostSelection(post.id)}
                 >
                   <img
                     src={`/storage/${post.photo.url}`}
@@ -71,8 +67,8 @@ const AddPosts = ({ album, userPosts, onClose }) => {
             )}
           </div>
 
-          {/* Botones de acción */}
-          <div className="flex justify-between mt-4">
+          {/* Botones de acción fijos debajo del listado de posts */}
+          <div className="bg-white py-4 flex justify-between border-t border-gray-300 sticky bottom-0 left-0 right-0 z-10">
             <button
               type="button"
               onClick={onClose}

--- a/resources/js/Components/Albums/FlipBook.jsx
+++ b/resources/js/Components/Albums/FlipBook.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import React from 'react';
 import HTMLFlipBook from "react-pageflip";
 
@@ -9,17 +9,33 @@ export default function FlipBook({ isOpen, onClose, album }) {
   // Referencia para el flipbook
   const flipBookRef = useRef(null);
 
-  // Estado para la página actual
+  // Estado para manejar el álbum completo
+  const [currentAlbum, setCurrentAlbum] = useState(album);
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
+  const [pages, setPages] = useState([]);  // Nuevo estado para manejar las páginas
 
-  const postsImpares = album.posts.length % 2 !== 0;
+  // Actualizar el estado del álbum cuando cambie el prop `album`
+  useEffect(() => {
+    setCurrentAlbum(album);
+    // Comprobar si el número de posts es impar
+    const updatedPages = [...album.posts];
 
-  // Funciones para manejar los eventos
-  const onPage = (e) => {
-    setPage(flipBookRef.current.pageFlip().getCurrentPageIndex() + 1);
-    setTotalPages(flipBookRef.current.pageFlip().getPageCount());
-    console.log('Página volteada:', e);
+    // Si el número de posts es impar, añadir una página vacía antes de la contraportada
+    if (updatedPages.length % 2 !== 0) {
+      updatedPages.push(null); // Añadimos una página vacía representada por `null`
+    }
+
+    // Establecer las páginas actualizadas
+    setPages(updatedPages);
+  }, [album]); // Se ejecuta cada vez que cambia `album`
+
+  // Función que se ejecuta cuando el flipbook cambia de página
+  const onPage = () => {
+    if (flipBookRef.current) {
+      setPage(flipBookRef.current.pageFlip().getCurrentPageIndex() + 1);
+      setTotalPages(flipBookRef.current.pageFlip().getPageCount());
+    }
   };
 
   const onChangeOrientation = (e) => {
@@ -30,7 +46,7 @@ export default function FlipBook({ isOpen, onClose, album }) {
     console.log('Estado cambiado:', e);
   };
 
-  // Funciones para el control de las páginas
+  // Funciones para controlar la navegación entre páginas
   const nextButtonClick = () => {
     if (flipBookRef.current) {
       flipBookRef.current.pageFlip().flipNext();
@@ -43,15 +59,17 @@ export default function FlipBook({ isOpen, onClose, album }) {
     }
   };
 
+  // Definir el tamaño de las páginas del flipbook
   const width = window.innerWidth;
   const height = width * (2 / 3);
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 overflow-hidden">
-      {/* Modal ocupa todo el viewport */}
       <div className="bg-white p-0 rounded-lg shadow-xl w-full h-full flex flex-col items-center overflow-hidden">
         {/* Título del álbum */}
-        <h2 className="text-2xl font-semibold mb-4 absolute top-4 left-1/2 transform -translate-x-1/2 z-10">{album.nombre}</h2>
+        <h2 className="text-2xl font-semibold mb-4 absolute top-4 left-1/2 transform -translate-x-1/2 z-10">
+          {currentAlbum.nombre}
+        </h2>
 
         <div className="flex items-center justify-center w-full h-full flex-grow overflow-hidden pl-10 pr-10">
           <HTMLFlipBook
@@ -71,74 +89,65 @@ export default function FlipBook({ isOpen, onClose, album }) {
             onChangeState={onChangeState}
             ref={flipBookRef}
           >
-            {/* Portada como una página dura */}
+            {/* Portada del álbum */}
             <div className="w-full h-full flex items-center justify-center">
               <div className="page-content w-full h-full">
                 <img
-                  src={`/storage/${album.portada}?t=${new Date().getTime()}`}
-                  alt={album.nombre}
+                  src={`/storage/${currentAlbum.portada}?t=${new Date().getTime()}`}
+                  alt={currentAlbum.nombre}
                   className="w-full h-full object-cover"
                 />
               </div>
             </div>
 
             {/* Páginas del álbum */}
-            {album.posts.map((post, index) => (
-              <div key={index} className="w-full h-full flex items-center justify-center">
-                <div className="page-content w-full h-full">
-                  <img
-                    src={`/storage/${post.photo.url}?t=${new Date().getTime()}`}
-                    alt={post.photo.localizacion || `Photo ${index + 1}`}
-                    className="w-full h-full object-cover"
-                  />
+            {pages.map((post, index) => (
+              post ? (
+                <div key={index} className="w-full h-full flex items-center justify-center">
+                  <div className="page-content w-full h-full">
+                    <img
+                      src={`/storage/${post.photo.url}?t=${new Date().getTime()}`}
+                      alt={post.photo.localizacion || `Photo ${index + 1}`}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
                 </div>
-              </div>
+              ) : (
+                // Si es una página vacía (null), crear una página vacía
+                <div key={index} className="w-full h-full flex items-center justify-center bg-gray-200">
+                  <div className="page-content w-full h-full"></div>
+                </div>
+              )
             ))}
 
-            {postsImpares ? (
-            <>
-                <div className="w-full h-full flex items-center justify-center bg-gray-200">
-                {/* Página vacía */}
-                </div>
-
-                <div className="w-full h-full flex items-center justify-center">
-                <div className="page-content w-full h-full">
-                    <img
-                    src={`/storage/${album.portada}?t=${new Date().getTime()}`}
-                    alt={album.nombre}
-                    className="w-full h-full object-cover"
-                    />
-                </div>
-                </div>
-            </>
-            ) : (
-            // Si no hay página vacía (postsImpares es false)
+            {/* Contraportada del álbum */}
             <div className="w-full h-full flex items-center justify-center">
-                <div className="page-content w-full h-full">
+              <div className="page-content w-full h-full">
                 <img
-                    src={`/storage/${album.portada}?t=${new Date().getTime()}`}
-                    alt={album.nombre}
-                    className="w-full h-full object-cover"
+                  src={`/storage/${currentAlbum.portada}?t=${new Date().getTime()}`}
+                  alt={currentAlbum.nombre}
+                  className="w-full h-full object-cover"
                 />
-                </div>
+              </div>
             </div>
-            )}
 
           </HTMLFlipBook>
         </div>
 
+        {/* Controles de navegación */}
         <div className="container">
           <div>
             <button type="button" onClick={prevButtonClick}>
               Página anterior
             </button>
-             <span> {page}</span> de <span> {totalPages} </span>
+            <span> {page}</span> de <span> {totalPages} </span>
             <button type="button" onClick={nextButtonClick}>
               Siguiente página
             </button>
           </div>
         </div>
 
+        {/* Botón de cierre */}
         <button
           onClick={onClose}
           className="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-900 absolute top-2 right-2 z-10"


### PR DESCRIPTION
Este PR soluciona el problema de visualización en el modal de agregar publicaciones al álbum, donde, al haber más publicaciones de las que se podían mostrar, los botones de "Cancelar" y "Agregar publicaciones" quedaban ocultos. Ahora, se ha implementado una funcionalidad de desplazamiento (scroll) entre las publicaciones, asegurando que los botones siempre sean visibles y accesibles.