### PR TITLE
Solución problema al dejar de compartir una publicación.

### DIFF
--- a/app/Http/Controllers/SharedPostController.php
+++ b/app/Http/Controllers/SharedPostController.php
@@ -45,6 +45,8 @@ class SharedPostController extends Controller
 
         $post->posteable()->associate($sharedPost);
         $post->save();
+
+        return back();
     }
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,11 +84,13 @@ Route::delete('/shared-posts/by-regular', function (Request $request) {
         ->first();
 
     if (!$sharedPost) {
-        return response()->json(['message' => 'No shared post found.'], 404);
+        return back();
     }
 
     $sharedPost->post()->delete();
     $sharedPost->delete();
+
+    return back();
 
 })->middleware('auth')->name('shared-posts.destroyByPostId');
 


### PR DESCRIPTION
Este PR soluciona un error que ocurría al dejar de compartir una publicación que ya no estaba compartida.