### PR TITLE
Solución error al ordenar por nombre de usuario

### DIFF
--- a/resources/js/Pages/Posts/Index.jsx
+++ b/resources/js/Pages/Posts/Index.jsx
@@ -70,7 +70,7 @@ export default function PostIndex() {
             } else if (sortField === 'created_at') {
                 return sortDirection === 'asc' ? new Date(a.created_at) - new Date(b.created_at) : new Date(b.created_at) - new Date(a.created_at);
             } else if (sortField === 'user_name') {
-                return sortDirection === 'asc' ? a.user.name.localeCompare(b.user.name) : b.user.name.localeCompare(a.user.name);
+                return sortDirection === 'asc' ? a.post.user.name.localeCompare(b.post.user.name) : b.post.user.name.localeCompare(a.post.user.name);
             }
             return 0;
         });


### PR DESCRIPTION
Este PR soluciona un error que ocurría al ordenar las publicaciones por nombre de usuario en la tabla de gestión del administrador.