### PR TITLE
Solución error comunidades en crear y editar publicación.

### DIFF
--- a/app/Http/Controllers/RegularPostController.php
+++ b/app/Http/Controllers/RegularPostController.php
@@ -46,10 +46,12 @@ class RegularPostController extends Controller
         $user = User::findOrFail(Auth::id());
 
         $communities = $user->communityMemberships()
+            ->where('community_role_id', '!=', 4) // aplica el filtro aquí
             ->with('community') // carga la relación community
             ->get()
             ->pluck('community') // extrae las comunidades
-            ->filter(); // elimina posibles null (por seguridad)
+            ->filter(); // elimina posibles null por seguridad
+
         return Inertia::render('Posts/Create', [
             'tags' => Tag::all(),
             'communities' => $communities,

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -28,6 +28,7 @@ class HandleInertiaRequests extends Middleware
             }
 
             $communities = $user->communityMemberships()
+                ->where('community_role_id', '!=', 4)
                 ->with('community') // carga la relación community
                 ->get()
                 ->pluck('community') // extrae las comunidades


### PR DESCRIPTION
Este PR soluciona un error que permitía a los usuarios añadir publicaciones en comunidades donde su solicitud de unión aún estaba pendiente.